### PR TITLE
Fixed user issues and some refactoring

### DIFF
--- a/keycloak/run.sh
+++ b/keycloak/run.sh
@@ -12,7 +12,7 @@ docker run \
   -p 8180:8180 \
   -v `pwd`/data:/opt/jboss/keycloak/data \
   -v `pwd`/radiusdemo-realm.json:/opt/jboss/keycloak/radiusdemo-realm.json \
-  -it jboss/keycloak:5.0.0 \
+  -it jboss/keycloak:6.0.1 \
   -b 0.0.0.0 \
   -Djboss.http.port=8180 \
   -Dkeycloak.migration.action=import \

--- a/radius/Dockerfile
+++ b/radius/Dockerfile
@@ -24,11 +24,6 @@ RUN echo "Enable PAM module" && \
     sed -i 's/#\s*pam/	pam/' /etc/freeradius/sites-enabled/default && \
     sed -i 's/#\s*pam/	pam/' /etc/freeradius/sites-enabled/inner-tunnel
 
-RUN echo "Enable PAM debugging" && \
-    touch /etc/pam_debug && \
-    echo '*.debug /var/log/debug.log' >> /etc/rsyslog.conf && \
-    test ! -f /var/log/debug.log && touch /var/log/debug.log
-
 RUN echo "# Instruct FreeRADIUS to use PAM to authenticate users"  >> /etc/freeradius/users && \
     echo "DEFAULT Auth-Type := PAM" >> /etc/freeradius/users && \
     sed -i "s/\s*secret\s*=\s*testing123/secret = $RADIUS_SECRET/" /etc/freeradius/clients.conf && \
@@ -37,5 +32,5 @@ RUN echo "# Instruct FreeRADIUS to use PAM to authenticate users"  >> /etc/freer
     echo "Configuring pam-exec-oauth2 PAM module" && \
     chmod 755 $OAUTH_PAM_PREFIX/pam-exec-oauth2 && \
     chmod 600 $OAUTH_PAM_PREFIX/pam-exec-oauth2.yaml
-    
+
 COPY pam/radiusd /etc/pam.d/radiusd

--- a/radius/Dockerfile
+++ b/radius/Dockerfile
@@ -2,10 +2,11 @@ FROM freeradius/freeradius-server:3.0.18
 
 ENV OAUTH_PAM_PREFIX /opt/pam-exec-oauth2
 ENV RADIUS_SECRET bubu123
+ENV DEBIAN_FRONTEND noninteractive
 
 # Note those tools are just used for debugging and could be removed
 RUN apt-get update && \
-    apt-get install -y less curl jq vim rsyslog
+    apt-get install -y less
 
 # Install OAuth2 PAM Module
 # --chown=freerad:freerad 
@@ -21,21 +22,20 @@ RUN echo "Enable PAM module" && \
     cd / && \
     echo "Enable PAM authentication" && \
     sed -i 's/#\s*pam/	pam/' /etc/freeradius/sites-enabled/default && \
-    sed -i 's/#\s*pam/	pam/' /etc/freeradius/sites-enabled/inner-tunnel && \
-    echo "Enable PAM debugging" && \
+    sed -i 's/#\s*pam/	pam/' /etc/freeradius/sites-enabled/inner-tunnel
+
+RUN echo "Enable PAM debugging" && \
     touch /etc/pam_debug && \
     echo '*.debug /var/log/debug.log' >> /etc/rsyslog.conf && \
-    test ! -f /var/log/debug.log && touch /var/log/debug.log && \
-    echo "# Instruct FreeRADIUS to use PAM to authenticate users"  >> /etc/freeradius/users && \
+    test ! -f /var/log/debug.log && touch /var/log/debug.log
+
+RUN echo "# Instruct FreeRADIUS to use PAM to authenticate users"  >> /etc/freeradius/users && \
     echo "DEFAULT Auth-Type := PAM" >> /etc/freeradius/users && \
     sed -i "s/\s*secret\s*=\s*testing123/secret = $RADIUS_SECRET/" /etc/freeradius/clients.conf && \
 #    echo "Add custom freeradius client" && \
 #    echo "client client144x {\n  ipaddr = 144.0.0.0/8\n  secret = $RADIUS_SECRET\n}" >> /etc/freeradius/clients.conf && \
     echo "Configuring pam-exec-oauth2 PAM module" && \
     chmod 755 $OAUTH_PAM_PREFIX/pam-exec-oauth2 && \
-    chmod 600 $OAUTH_PAM_PREFIX/pam-exec-oauth2.yaml && \
-    sed -i 's/@include/#@include/g' /etc/pam.d/radiusd && \
-    echo "auth	sufficient	pam_exec.so	debug	expose_authtok	stdout	/opt/pam-exec-oauth2/pam-exec-oauth2 --debug" >> /etc/pam.d/radiusd && \
-    echo Add user tester && \
-    useradd tester && \
-    echo "done."
+    chmod 600 $OAUTH_PAM_PREFIX/pam-exec-oauth2.yaml
+    
+COPY pam/radiusd /etc/pam.d/radiusd

--- a/radius/pam/radiusd
+++ b/radius/pam/radiusd
@@ -11,6 +11,6 @@
 #@include common-session
 
 account required                        pam_permit.so
-auth	[success=1 default=ignore]      pam_exec.so debug   expose_authtok	log=/var/log/freeradius/pam.log	/opt/pam-exec-oauth2/pam-exec-oauth2 --debug
+auth	[success=1 default=ignore]      pam_exec.so     expose_authtok  log=/var/log/freeradius/pam.log	/opt/pam-exec-oauth2/pam-exec-oauth2
 auth    requisite                       pam_deny.so
 auth    required                        pam_permit.so

--- a/radius/pam/radiusd
+++ b/radius/pam/radiusd
@@ -1,0 +1,16 @@
+#
+# /etc/pam.d/radiusd - PAM configuration for FreeRADIUS
+#
+
+# We fall back to the system default in /etc/pam.d/common-*
+#
+
+#@include common-auth
+#@include common-account
+#@include common-password
+#@include common-session
+
+account required                        pam_permit.so
+auth	[success=1 default=ignore]      pam_exec.so debug   expose_authtok	log=/var/log/freeradius/pam.log	/opt/pam-exec-oauth2/pam-exec-oauth2 --debug
+auth    requisite                       pam_deny.so
+auth    required                        pam_permit.so

--- a/readme.md
+++ b/readme.md
@@ -85,8 +85,4 @@ Received Access-Accept Id 139 from 127.0.0.1:1812 to 127.0.0.1:47297 length 20
 
 # Issues
 
-## Radius users needs to have unix accounts
-The current configuration requires that a radius user has an existing unix account.
-For the sake of the example we create a `tester` user in the `Dockerfile`.
-
-I'm still looking for the proper `PAM` configuration to not require unix accounts for radius users.
+No known issues so far.


### PR DESCRIPTION
Hi Thomas,

I fixed the local user issue by adding `account required pam_permit.so` to the PAM config.
This allows all users to try a login without checking for a user account. As the Keycloak checks user and password imho this is a valid setting.

Also removed the debug logging und bumped the Keycloak to 6.0.1

Kind regards

Thomas Zub